### PR TITLE
bugfix: card display error on the main page.

### DIFF
--- a/assets/data/cards_pt-br.json
+++ b/assets/data/cards_pt-br.json
@@ -158,7 +158,7 @@
       "description": "O Optional Chaining é um recurso no Javascript para lidar com situações onde você precisa acessar propriedades de objetos aninhados mas não tem certeza se essas propriedades existem realmente, Isso ajuda a evitar erros de 'TypeError' quando tenta acessar algo que não foi definido.",
       "content": {
         "code": "const pessoa = nome?.cidade?.endereco;"
-      },
+      }
     },
     {
       "title": "Bug",


### PR DESCRIPTION
The json file contained an unwanted comma that caused a syntax error, it was removed and the app started working again.

### Page with error:

![image](https://github.com/levxyca/diciotech/assets/97963191/9a889868-c129-4597-9f08-71b2bf23f50d)


### Page with correction:

![image](https://github.com/levxyca/diciotech/assets/97963191/42dbc95f-4dfd-4bf4-be64-8e9f24533355)

