### PR TITLE
GitHub Action personalizada para verificar issue no PR

### DIFF
--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, edited]
 
+permissions:
+  pull-requests: write
+
 jobs:
   check-linked-issue:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -1,0 +1,30 @@
+name: Check for linked issue
+
+on:
+  pull_request:
+    types: [opened, edited]
+
+jobs:
+  check-linked-issue:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check if PR has linked issue
+      id: check_issue
+      run: |
+        issue_pattern='#[0-9]+'
+        if [[ "${{ github.event.pull_request.body }}" =~ $issue_pattern ]]; then
+          echo "Issue linked in PR description."
+        else
+          echo "::error::No issue linked! Please link to an issue using '#<issue_number>' or create a new issue."
+          exit 1
+        fi
+
+    - name: Post comment on PR (if no issue linked)
+      if: failure()
+      uses: actions-ecosystem/action-create-comment@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        issue-number: ${{ github.event.pull_request.number }}
+        body: |
+          ⚠️ Poxa, parece que não temos nenhuma issue vinculada a este PR. Para facilitar para todas as pessoas contribuidoras e mantenedoras desse projeto, além da organização, por favor, vincule uma issue a esse PR incluindo #<número_da_issue> na descrição do PR ou crie uma nova issue e atualize o PR.

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -30,4 +30,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         number: ${{ github.event.pull_request.number }}
         body: |
-          ⚠️ Poxa @${{ github.actor }}, parece que não temos nenhuma issue vinculada a este PR. Para facilitar para todas as pessoas contribuidoras e mantenedoras desse projeto, além da organização, por favor, vincule uma issue a esse PR incluindo #<número_da_issue> na descrição do PR ou crie uma nova issue e atualize o PR.
+          ⚠️ Poxa @${{ github.actor }}, parece que não temos nenhuma issue vinculada a este PR. Para facilitar para todas as pessoas contribuidoras e mantenedoras desse projeto, além da organização, por favor, vincule uma issue a esse PR incluindo #<número_da_issue> na descrição do PR ou crie uma nova issue e atualize o PR. Se precisar de qualquer ajuda para isso, pode chamar a @levxyca 💙🫰🏻

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -30,4 +30,4 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
-          ⚠️ Poxa, parece que não temos nenhuma issue vinculada a este PR. Para facilitar para todas as pessoas contribuidoras e mantenedoras desse projeto, além da organização, por favor, vincule uma issue a esse PR incluindo #<número_da_issue> na descrição do PR ou crie uma nova issue e atualize o PR.
+          ⚠️ Poxa @${{ github.actor }}, parece que não temos nenhuma issue vinculada a este PR. Para facilitar para todas as pessoas contribuidoras e mantenedoras desse projeto, além da organização, por favor, vincule uma issue a esse PR incluindo #<número_da_issue> na descrição do PR ou crie uma nova issue e atualize o PR.

--- a/.github/workflows/issue-check.yml
+++ b/.github/workflows/issue-check.yml
@@ -27,7 +27,7 @@ jobs:
       if: failure()
       uses: actions-ecosystem/action-create-comment@v1
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        issue-number: ${{ github.event.pull_request.number }}
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        number: ${{ github.event.pull_request.number }}
         body: |
           ⚠️ Poxa @${{ github.actor }}, parece que não temos nenhuma issue vinculada a este PR. Para facilitar para todas as pessoas contribuidoras e mantenedoras desse projeto, além da organização, por favor, vincule uma issue a esse PR incluindo #<número_da_issue> na descrição do PR ou crie uma nova issue e atualize o PR.


### PR DESCRIPTION
## Descrição de PR

Criação de uma GitHub Action personalizada para verificar issue no PR. Esse GitHub Action personalizado verifica a presença de uma referência a uma issue no corpo do PR. Se não houver uma referência, o Action orienta a pessoa autora do PR a adicionar um link a uma issue ou criar uma nova.

### Issue relacionado

#186 

## Motivações

Melhorar e facilitar a organização do projeto Diciotech.
