### PR TITLE
Adicionado workflow pra validar o json com os dados

### DIFF
--- a/.github/workflows/json-yaml-validate.yml
+++ b/.github/workflows/json-yaml-validate.yml
@@ -1,0 +1,24 @@
+name: json-yaml-validate
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write # enable write permissions for pull request comments
+
+jobs:
+  json-yaml-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: json-yaml-validate
+        id: json-yaml-validate
+        uses: GrantBirki/json-yaml-validate@v3.2.1 # replace with the latest version
+        with:
+          base_dir: assets/data # base directory to search for files
+          comment: "true" # enable comment mode


### PR DESCRIPTION
## Descrição de PR

Criado um workflow pra validar o json com os dados ao submeter um PR. Valida qualquer arquivo json que estiver dentro de `assets/data/`, já pensando em suportar uma estrutura de dados dividida em múltiplos arquivos.

Caso encontre algum erro, ele aponta qual o nome do arquivo com erros (não o erro em si) como pode ser visto [no exemplo do workflow](https://github.com/marketplace/actions/json-yaml-validate#pull-request-comment).

### Issue relacionado

- https://github.com/levxyca/diciotech/pull/151#issuecomment-2358552275
- #171

## Motivações

Validar o JSON na PR ajuda no caso da modificação ter sido feita na interface online do GitHub, por exemplo.
