### PR TITLE
Adição do termo Kanban (em português e inglês)

### DIFF
--- a/_data/en-us/k.yml
+++ b/_data/en-us/k.yml
@@ -1,0 +1,9 @@
+- title: Kanban
+  tags:
+    - Framework
+  id: kanban
+  description: "Kanban is a visual work management system that uses cards and columns  
+    on a board to manage the flow of tasks in a project. Its origin is Japanese and 
+    it means 'signaling', and its goal is to increase efficiency, transparency, and 
+    productivity by allowing teams to visualize progress and identify bottlenecks in 
+    the workflow."

--- a/_data/pt-br/k.yml
+++ b/_data/pt-br/k.yml
@@ -1,0 +1,9 @@
+- title: Kanban
+  tags:
+    - Framework
+  id: kanban
+  description: "Kanban é um sistema visual de gestão de trabalho que utiliza cartões e 
+    colunas em um quadro para gerenciar o fluxo de tarefas de um projeto. Sua origem 
+    é japonesa e significa 'sinalização', e seu objetivo é aumentar a eficiência, a 
+    transparência e a produtividade, permitindo que as equipes visualizem o progresso 
+    e identifiquem gargalos no fluxo de trabalho."


### PR DESCRIPTION
Adicionei o termo Kanban nas versões em português e inglês ao repositório Diciotech.
A definição descreve o Kanban como um sistema visual de gestão de trabalho, explicando sua origem, propósito e benefícios para equipes de desenvolvimento e gestão de projetos.