### PR TITLE
Adição do termo Markup Language / Linguagem de Marcação

### DIFF
--- a/_data/en-us/c.yml
+++ b/_data/en-us/c.yml
@@ -185,7 +185,7 @@
   id: core_web_vitals
   description: "A set of Google metrics that measure user experience on the Web,
     focusing on loading, interactivity, and visual stability. The main metrics are:
-    LCP (Largest Contentful Paint), ideal up to 2.5s; INP (Interaction to Next Paint),  
+    LCP (Largest Contentful Paint), ideal up to 2.5s; INP (Interaction to Next Paint),
     ideal up to 200ms; and CLS (Cumulative Layout Shift), ideal up to 0.1. For a
     page to be considered passing, it must meet the recommended thresholds at the
     75th percentile of users, on desktop and mobile."

--- a/_data/en-us/k.yml
+++ b/_data/en-us/k.yml
@@ -2,8 +2,8 @@
   tags:
     - Framework
   id: kanban
-  description: "Kanban is a visual work management system that uses cards and columns  
-    on a board to manage the flow of tasks in a project. Its origin is Japanese and 
-    it means 'signaling', and its goal is to increase efficiency, transparency, and 
-    productivity by allowing teams to visualize progress and identify bottlenecks in 
+  description: "Kanban is a visual work management system that uses cards and columns
+    on a board to manage the flow of tasks in a project. Its origin is Japanese and
+    it means 'signaling', and its goal is to increase efficiency, transparency, and
+    productivity by allowing teams to visualize progress and identify bottlenecks in
     the workflow."

--- a/_data/en-us/m.yml
+++ b/_data/en-us/m.yml
@@ -24,11 +24,14 @@
     and relationships more easily than in the original high-dimensional space.
 - title: Markup Language
   tags:
-  - Concept
+    - Concept
   id: markup_language
-  description: A markup language is a set of symbols and rules used to structure,
-    format, and organize the content of a document, distinguishing the text from the
-    display instructions.
+  description: A markup language is used to structure and describe the content of a
+    document through tags. It indicates what each part of the text represents (such
+    as title, paragraph, or link), instead of executing program logic. For example,
+    in HTML, <h1> defines a title and <p> defines a paragraph.
+  content:
+    code: "<h1>Page title</h1><p>This is a paragraph.</p>"
 - title: Material
   tags:
     - Design

--- a/_data/en-us/m.yml
+++ b/_data/en-us/m.yml
@@ -22,6 +22,13 @@
     where relationships between the data are more easily identified. The idea is that
     by mapping the data to a low-dimensional space, it is possible to find patterns
     and relationships more easily than in the original high-dimensional space.
+- title: Markup Language
+  tags:
+  - Concept
+  id: markup_language
+  description: A markup language is a set of symbols and rules used to structure,
+    format, and organize the content of a document, distinguishing the text from the
+    display instructions.
 - title: Material
   tags:
     - Design

--- a/_data/pt-br/b.yml
+++ b/_data/pt-br/b.yml
@@ -4,7 +4,7 @@
     - Back-end
   id: database
   description: "Banco de dados é um sistema organizado projetado para armazenar, gerenciar
-    e recuperar informações de maneira eficiente. Ele pode ser relacional, utilizando 
+    e recuperar informações de maneira eficiente. Ele pode ser relacional, utilizando
     tabelas e a linguagem SQL para consultas e manipulação de dados, ou não relacional
     (NoSQL), que emprega diferentes modelos como documentos, grafos ou chave-valor.
     São essenciais para o funcionamento de aplicações que processam grandes volumes

--- a/_data/pt-br/k.yml
+++ b/_data/pt-br/k.yml
@@ -2,8 +2,8 @@
   tags:
     - Framework
   id: kanban
-  description: "Kanban é um sistema visual de gestão de trabalho que utiliza cartões e 
-    colunas em um quadro para gerenciar o fluxo de tarefas de um projeto. Sua origem 
-    é japonesa e significa 'sinalização', e seu objetivo é aumentar a eficiência, a 
-    transparência e a produtividade, permitindo que as equipes visualizem o progresso 
+  description: "Kanban é um sistema visual de gestão de trabalho que utiliza cartões e
+    colunas em um quadro para gerenciar o fluxo de tarefas de um projeto. Sua origem
+    é japonesa e significa 'sinalização', e seu objetivo é aumentar a eficiência, a
+    transparência e a produtividade, permitindo que as equipes visualizem o progresso
     e identifiquem gargalos no fluxo de trabalho."

--- a/_data/pt-br/l.yml
+++ b/_data/pt-br/l.yml
@@ -32,9 +32,11 @@
     É uma linguagem de programação que está mais próxima da linguagem de máquina.
 - title: Linguagem de Marcação
   tags:
-  - Conceito
+    - Conceito
   id: markup_language
-  description: Uma linguagem de marcação é um conjunto de símbolos e regras usados
-    para estruturar, formatar e organizar o conteúdo de um documento, diferenciando
-    o que é texto do que é instrução de exibição.
-
+  description: Linguagem de marcação é usada para estruturar e descrever o conteúdo
+    de um documento por meio de tags. Ela indica o que cada parte do texto representa
+    (como título, parágrafo ou link), em vez de executar lógica de programação. Por
+    exemplo, no HTML, <h1> define um título e <p> define um parágrafo.
+  content:
+    code: "<h1>Título da página</h1><p>Este é um parágrafo.</p>"

--- a/_data/pt-br/l.yml
+++ b/_data/pt-br/l.yml
@@ -30,3 +30,11 @@
   id: low_level_language
   description: Linguagem de programação que possui pouca ou nenhuma abstração do computador.
     É uma linguagem de programação que está mais próxima da linguagem de máquina.
+- title: Linguagem de Marcação
+  tags:
+  - Conceito
+  id: markup_language
+  description: Uma linguagem de marcação é um conjunto de símbolos e regras usados
+    para estruturar, formatar e organizar o conteúdo de um documento, diferenciando
+    o que é texto do que é instrução de exibição.
+


### PR DESCRIPTION
## Descrição de PR

Inclusão do termo "Markup Language" (Inglês) e "Linguagem de Marcação" (Português) ao dicionário.

### Issue relacionado

- #000

## Motivações

O termo é fundamental para o entendimento de tecnologias centrais do projeto, como Jekyll (Markdown) e Liquid, além de ser um conceito base no desenvolvimento de software.

### Informações adicionais

- Adicionado `markup_language` em `_data/en-us/m.yml`.
- Adicionado `markup_language` em `_data/pt-br/l.yml`.