### PR TITLE
Adiciona explicação sobre Fundação OWASP em pt-br e en-us

### DIFF
--- a/_data/en-us/o.yml
+++ b/_data/en-us/o.yml
@@ -55,3 +55,11 @@
     performs very well on the metrics for the training data, but performs poorly on
     the test data. Overfitting can be caused by several factors, such as a very complex
     model, a very small training dataset, among others.
+- title: OWASP
+  tags:
+    - Concept
+    - Cybersecurity
+  id: owasp_foundation
+  description: OWASP is a non-profit foundation focused on improving the security of
+    websites and software. It publishes free materials like guides, best practices,
+    and risk lists (such as the OWASP Top 10) to help teams build safer applications.

--- a/_data/pt-br/o.yml
+++ b/_data/pt-br/o.yml
@@ -56,3 +56,12 @@
     ruim nos dados de teste. O overfitting pode ser causado por vários fatores, como
     um modelo muito complexo, um conjunto de dados de treinamento muito pequeno, entre
     outros.
+- title: OWASP
+  tags:
+    - Conceito
+    - Segurança cibernética
+  id: owasp_foundation
+  description: OWASP é uma fundação sem fins lucrativos focada em melhorar a segurança
+    de sites e sistemas. Ela cria materiais gratuitos, como guias, boas práticas e
+    listas de riscos (como o OWASP Top 10), para ajudar equipes a desenvolver aplicações
+    mais seguras.


### PR DESCRIPTION
## Descrição de PR

Este PR adiciona o termo OWASP ao dicionário para explicar, de forma simples, o que é a fundação e como ela ajuda na segurança de sites e sistemas.

### Issue relacionado

- #000

## Motivações

OWASP é uma referência muito comum em segurança, e faltava um termo direto para explicar rapidamente o que ela representa.

### Informações adicionais

- Arquivo atualizado em português: `_data/pt-br/o.yml`
- Arquivo atualizado em inglês: `_data/en-us/o.yml`
- `id` usado nos dois idiomas: `owasp_foundation`
